### PR TITLE
fix: dish_ingredients migrate

### DIFF
--- a/src/database/knex/migrations/20230414201613_create_dish_ingredients.js
+++ b/src/database/knex/migrations/20230414201613_create_dish_ingredients.js
@@ -7,7 +7,6 @@ exports.up = knex =>
     table.increments('id');
     table.integer('dish_id').notNullable().references('id').inTable('dishes').onDelete('CASCADE');
     table.text('name').notNullable();
-    table.string('name').notNullable();
   });
 
 /**


### PR DESCRIPTION
duplicated name field